### PR TITLE
using css filter, because it's more accurate and has the same support at the svg feBlend filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
       width: 100%;
       height: 100%;
       
-      filter: url(filter.svg#myfilter);
+      mix-blend-mode: luminosity;
     }
     
     @keyframes rainbow {


### PR DESCRIPTION
Turns out, the svg blend filter does not work in IE/Edge and Safari, so might as well use the single CSS property than a separate filter svg.

#4 